### PR TITLE
adding google-spreadsheet as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "name": "Yusuf Kör, yusuf.koer@googlemail.com"
   },
   "dependencies": {
+    "google-spreadsheet": "^2.0.4"
   },
   "description": "A simple Google Spreadsheet input and output node.",
   "name": "node-red-contrib-google-spreadsheet",


### PR DESCRIPTION
If I don't have the "google-spreadsheet" installed as global dependencies or If I am referencing my node_modules dependencies from` cd $HOME/.node-red`. running `node-red` gives Error: Cannot find module 'google-spreadsheet'. This will fix that issue.